### PR TITLE
Dev Add LauncherGSLM project and update shortcut logic

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -21,16 +21,20 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Restore
-        run: dotnet restore GameStoreLibraryManager/GameStoreLibraryManager.csproj
+      - name: Restore Solution
+        run: dotnet restore GameStoreLibraryManager.sln
         shell: pwsh
 
-      - name: Build (Release)
-        run: dotnet build GameStoreLibraryManager/GameStoreLibraryManager.csproj --configuration Release --no-restore
+      - name: Build Solution (Release)
+        run: dotnet build GameStoreLibraryManager.sln --configuration Release --no-restore
         shell: pwsh
 
-      - name: Publish (self-contained)
+      - name: Publish Main App
         run: dotnet publish GameStoreLibraryManager/GameStoreLibraryManager.csproj -c Release -o ./publish
+        shell: pwsh
+
+      - name: Publish Launcher
+        run: dotnet publish LauncherGSLM/LauncherGSLM.csproj -c Release -o ./publish
         shell: pwsh
 
       - name: Zip publish folder

--- a/GameStoreLibraryManager.sln
+++ b/GameStoreLibraryManager.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0.0
+MinimumVisualStudioVersion = 10.0.0.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameStoreLibraryManager", "GameStoreLibraryManager\GameStoreLibraryManager.csproj", "{A5E518E9-1D62-46A2-86B5-D3558197A23F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LauncherGSLM", "LauncherGSLM\LauncherGSLM.csproj", "{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5E518E9-1D62-46A2-86B5-D3558197A23F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5E518E9-1D62-46A2-86B5-D3558197A23F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5E518E9-1D62-46A2-86B5-D3558197A23F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5E518E9-1D62-46A2-86B5-D3558197A23F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A1B2C3D4-E5F6-7890-1234-567890ABCDEF}
+	EndGlobalSection
+EndGlobal

--- a/GameStoreLibraryManager/GameStoreLibraryManager.csproj
+++ b/GameStoreLibraryManager/GameStoreLibraryManager.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <ProjectGuid>{A5E518E9-1D62-46A2-86B5-D3558197A23F}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>

--- a/GameStoreLibraryManager/Program.cs
+++ b/GameStoreLibraryManager/Program.cs
@@ -183,6 +183,57 @@ namespace GameStoreLibraryManager
             }
 
             var logger = new SimpleLogger("last_scan.log");
+            
+            // Force recreation of internal .bat files IF they point to the old executable
+            try
+            {
+                var filesToScan = new[]
+                {
+                    ".GSLM Settings.bat",
+                    ".Amazon Luna.bat",
+                    "Amazon Luna.bat",
+                    ".Xbox Cloud Gaming.bat"
+                };
+
+                var romsPaths = new[]
+                {
+                    PathManager.SteamRomsPath,
+                    Path.Combine(PathManager.SteamRomsPath, "Not Installed"),
+                    PathManager.EpicRomsPath,
+                    Path.Combine(PathManager.EpicRomsPath, "Not Installed"),
+                    PathManager.GogRomsPath,
+                    Path.Combine(PathManager.GogRomsPath, "Not Installed"),
+                    PathManager.AmazonRomsPath,
+                    Path.Combine(PathManager.AmazonRomsPath, "Not Installed"),
+                    PathManager.XboxRomsPath,
+                    Path.Combine(PathManager.XboxRomsPath, "Not Installed")
+                };
+
+                foreach (var path in romsPaths)
+                {
+                    if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) continue;
+                    foreach (var file in filesToScan)
+                    {
+                        var filePath = Path.Combine(path, file);
+                        if (File.Exists(filePath))
+                        {
+                            try
+                            {
+                                var content = File.ReadAllText(filePath);
+                                // Delete the file only if it contains a call to the old executable name
+                                if (content.IndexOf("GameStoreLibraryManager.exe", StringComparison.OrdinalIgnoreCase) >= 0)
+                                {
+                                    File.Delete(filePath);
+                                    logger.Log($"[Cleanup] Deleted outdated shortcut to force recreation: {file}");
+                                }
+                            }
+                            catch {}
+                        }
+                    }
+                }
+            }
+            catch {}
+
             // Debug: capture raw command line and args for normal mode
             try
             {

--- a/GameStoreLibraryManager/src/Common/ShortcutManager.cs
+++ b/GameStoreLibraryManager/src/Common/ShortcutManager.cs
@@ -85,9 +85,17 @@ namespace GameStoreLibraryManager.Common
                 string shortcutPath = Path.Combine(romsPath, fileName);
 
                 if (File.Exists(shortcutPath)) return;
+                
+                // On construit le chemin vers LauncherGSLM.exe, en supposant qu'il est dans le même répertoire
+                // que GameStoreLibraryManager.exe.
+                var mainExePath = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "GameStoreLibraryManager.exe");
+                var mainExeDir = Path.GetDirectoryName(mainExePath);
+                var launcherExePath = Path.Combine(mainExeDir, "LauncherGSLM.exe");
 
-                var exePath = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "GameStoreLibraryManager.exe");
-                string shortcutContent = $"@echo off\r\n\"{exePath}\" {shortcutArgs}\r\n";
+                // Si LauncherGSLM.exe n'existe pas, on se rabat sur l'ancien comportement par sécurité.
+                var exeToUse = File.Exists(launcherExePath) ? launcherExePath : mainExePath;
+
+                string shortcutContent = $"@echo off\r\n\"{exeToUse}\" {shortcutArgs}\r\n";
                 try
                 {
                     File.WriteAllText(shortcutPath, shortcutContent, Encoding.UTF8);

--- a/LauncherGSLM/LauncherGSLM.csproj
+++ b/LauncherGSLM/LauncherGSLM.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{B4F7C7B0-1C7E-4E6A-8A1D-9B2F5E6B7A8C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>LauncherGSLM</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/LauncherGSLM/Program.cs
+++ b/LauncherGSLM/Program.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+using System.Linq;
+
+namespace LauncherGSLM
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            try
+            {
+                var launcherPath = AppContext.BaseDirectory;
+                
+                // Logique de recherche améliorée :
+                // 1. Chercher dans le même répertoire que le lanceur.
+                // 2. Si non trouvé, chercher dans le répertoire parent.
+                var gslmPath = Path.Combine(launcherPath, "GameStoreLibraryManager.exe");
+                if (!File.Exists(gslmPath))
+                {
+                    gslmPath = Path.GetFullPath(Path.Combine(launcherPath, "..", "GameStoreLibraryManager.exe"));
+                }
+
+
+                if (!File.Exists(gslmPath))
+                {
+                    MessageBox.Show($"Erreur: GameStoreLibraryManager.exe non trouvé.\nCherché dans:\n- {Path.Combine(launcherPath, "GameStoreLibraryManager.exe")}\n- {Path.GetFullPath(Path.Combine(launcherPath, "..", "GameStoreLibraryManager.exe"))}", "LauncherGSLM Erreur", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return -1;
+                }
+
+                // Préparer les arguments pour le processus enfant
+                var arguments = string.Join(" ", args.Select(arg => $"\"{arg}\""));
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = gslmPath,
+                    Arguments = arguments,
+                    UseShellExecute = false // Important pour une surveillance fiable
+                };
+
+                // Lancer le processus et attendre sa fin
+                using (var process = Process.Start(startInfo))
+                {
+                    if (process == null)
+                    {
+                        MessageBox.Show("Erreur: N'a pas pu démarrer le processus GameStoreLibraryManager.exe.", "LauncherGSLM Erreur", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return -1;
+                    }
+                    
+                    // Attendre que le processus se termine
+                    process.WaitForExit();
+                    
+                    // Retourner le code de sortie du processus enfant
+                    return process.ExitCode;
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Une erreur inattendue est survenue:\n{ex.Message}", "LauncherGSLM Erreur Critique", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return -1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces the LauncherGSLM project to act as a launcher for GameStoreLibraryManager.exe. Updates shortcut creation logic to use LauncherGSLM.exe if available, falling back to the main executable otherwise. Adds cleanup logic to remove outdated .bat shortcuts referencing the old executable, ensuring shortcuts are recreated with the new launcher. Updates solution and project files to include the new project.
45bc4e4454d09345c4c4944621bed700db352435

_**Added to address RetroBat's new .bat file handling. Having been unable to resolve an issue with the execution of GameStoreLibraryManager.exe, I added the launcher so that emulatorLauncher doesn't lose focus on the executable.**_


