### PR TITLE
Add SteamGridDB scraper & improve media scraping

### DIFF
--- a/GameStoreLibraryManager/GameStoreLibraryManager.csproj.user
+++ b/GameStoreLibraryManager/GameStoreLibraryManager.csproj.user
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+  <ItemGroup>
+    <Compile Update="src\Auth\AuthBrowserForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Common\AutoClosingMessageBox.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Common\ExitOverlayForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Common\PrereqForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Luna\LunaBrowserForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Menu\MenuForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="src\Menu\ModernToggleSwitch.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="src\Xbox\XboxCloudGamingForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/GameStoreLibraryManager/src/Auth/AuthBrowserForm.cs
+++ b/GameStoreLibraryManager/src/Auth/AuthBrowserForm.cs
@@ -111,9 +111,16 @@ namespace GameStoreLibraryManager.Auth
             }
 
             // Also try to detect from page content if a content regex is provided (e.g., Steam API key on page)
+            // CRITICAL: We only trigger this on the target redirect URL if one is provided to avoid false positives on login pages (e.g. CSRF tokens)
             if (_contentRegex != null)
             {
-                _ = TryDetectCodeFromContentAsync();
+                bool shouldTry = string.IsNullOrEmpty(_postLoginRedirectUrl) || 
+                                 (_lastNavigatedUrl != null && _lastNavigatedUrl.StartsWith(_postLoginRedirectUrl, StringComparison.OrdinalIgnoreCase));
+                
+                if (shouldTry)
+                {
+                    _ = TryDetectCodeFromContentAsync();
+                }
             }
 
             // Auto-redirect after login for providers like Epic

--- a/GameStoreLibraryManager/src/Auth/AuthUiLauncher.cs
+++ b/GameStoreLibraryManager/src/Auth/AuthUiLauncher.cs
@@ -171,6 +171,26 @@ namespace GameStoreLibraryManager.Auth
                             }
                         });
                     }
+                case "steamgriddb_profile":
+                    {
+                        var profileApiUrl = "https://www.steamgriddb.com/profile/api";
+                        var form = new AuthBrowserForm("SteamGridDB Profile", profileApiUrl, codeRegex: null, steamPasteMode: false, contentRegex: null);
+                        return (form, null); // No action on code detection
+                    }
+                case "steamgriddb":
+                    {
+                        var loginUrl = "https://www.steamgriddb.com/login";
+                        var profileApiUrl = "https://www.steamgriddb.com/profile/api";
+                        // SteamGridDB API keys are typically 32-char hex strings
+                        var contentRegex = new Regex(@"\b([0-9a-f]{32})\b", RegexOptions.IgnoreCase);
+                        var form = new AuthBrowserForm("SteamGridDB", loginUrl, codeRegex: null, steamPasteMode: false, contentRegex: contentRegex, postLoginRedirectUrl: profileApiUrl);
+                        return (form, val =>
+                        {
+                            var target = Path.Combine(PathManager.ApiKeyPath, "steamgriddb.apikey");
+                            Directory.CreateDirectory(PathManager.ApiKeyPath);
+                            File.WriteAllText(target, val.Trim());
+                        });
+                    }
                 default:
                     return (null, null);
             }

--- a/GameStoreLibraryManager/src/Common/AutoClosingMessageBox.resx
+++ b/GameStoreLibraryManager/src/Common/AutoClosingMessageBox.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GameStoreLibraryManager/src/Common/Config.cs
+++ b/GameStoreLibraryManager/src/Common/Config.cs
@@ -59,8 +59,11 @@ namespace GameStoreLibraryManager.Common
             new ConfigOption { Key = "rescrape_incomplete_games", Value = "false", Comment = "Force metadata scraping for games that already have some, but incomplete, metadata." },
             new ConfigOption { Key = "create_gslm_shortcut", Value = "true", Comment = "Create a shortcut to GSLM settings in each store's roms directory." },
             new ConfigOption { Key = "hfsplay_scraper_media_types", Value = "", Comment = "Media types to scrape from HFSPlay, separated by commas." },
-            new ConfigOption { Key = "steam_scraper_media_types", Value = "marquee,fanart,video", Comment = "Media types to scrape from Steam, separated by commas." },
-            new ConfigOption { Key = "gog_scraper_media_types", Value = "image,thumb", Comment = "Media types to scrape from GOG, separated by commas." },
+            new ConfigOption { Key = "steam_scraper_media_types", Value = "video", Comment = "Media types to scrape from Steam, separated by commas." },
+            new ConfigOption { Key = "gog_scraper_media_types", Value = "thumb", Comment = "Media types to scrape from GOG, separated by commas." },
+            new ConfigOption { Key = "steamgriddb_scraper_media_types", Value = "marquee,fanart,image", Comment = "Media types to scrape from SteamGridDB, separated by commas." },
+            new ConfigOption { Key = "steamgriddb_api_key", Value = "", Comment = "API Key for SteamGridDB (get it at steamgriddb.com/profile/api)." },
+            new ConfigOption { Key = "steamgriddb_enable_token_generation", Value = "false", Comment = "Enable automated SteamGridDB API key retrieval via login UI." },
 
             new ConfigOption { Key = SectionHeaderKey, Value = "", Comment = "Global Options - Security" },
             new ConfigOption { Key = "enable_dpapi_protection", Value = "false", Comment = "Protect *.token and *.apikey files with Windows DPAPI (CurrentUser)." },

--- a/GameStoreLibraryManager/src/Common/MediaDownloader.cs
+++ b/GameStoreLibraryManager/src/Common/MediaDownloader.cs
@@ -10,7 +10,7 @@ namespace GameStoreLibraryManager.Common
     {
         private readonly HttpClient _httpClient;
         private readonly SimpleLogger _logger;
-        private static readonly List<string> SupportedExtensions = new List<string> { ".jpg", ".png", ".gif", ".mp4" };
+        private static readonly List<string> SupportedExtensions = new List<string> { ".jpg", ".png", ".gif", ".mp4", ".webm", ".mpd", ".m3u8" };
 
 
         public MediaDownloader(SimpleLogger logger)
@@ -82,6 +82,13 @@ namespace GameStoreLibraryManager.Common
                     return ".gif";
                 case "video/mp4":
                     return ".mp4";
+                case "video/webm":
+                    return ".webm";
+                case "application/dash+xml":
+                    return ".mpd";
+                case "application/x-mpegurl":
+                case "application/vnd.apple.mpegurl":
+                    return ".m3u8";
                 default:
                     return ".jpg"; // Default to jpg for unknown image types
             }

--- a/GameStoreLibraryManager/src/Common/PrereqForm.resx
+++ b/GameStoreLibraryManager/src/Common/PrereqForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GameStoreLibraryManager/src/Common/SplashOverlay.cs
+++ b/GameStoreLibraryManager/src/Common/SplashOverlay.cs
@@ -12,8 +12,10 @@ namespace GameStoreLibraryManager.Common
         private Form form;
         private Label titleLabel;
         private Label percentLabel;
+        private Button stopButton;
         private int currentPercent;
         private int targetPercent;
+        public bool StopClicked { get; private set; } = false;
         private volatile bool shouldClose = false;
         private readonly string initialText;
         private readonly int initialPercent;
@@ -101,6 +103,30 @@ namespace GameStoreLibraryManager.Common
                 Font = new Font("Segoe UI", 11f, FontStyle.Regular)
             };
 
+            stopButton = new Button
+            {
+                Text = "STOP",
+                Size = new Size(120, 36),
+                FlatStyle = FlatStyle.Flat,
+                ForeColor = Color.White,
+                BackColor = Color.FromArgb(180, 0, 0),
+                Font = new Font("Segoe UI", 9f, FontStyle.Bold),
+                Visible = false, // Hidden by default
+                Cursor = Cursors.Hand
+            };
+            stopButton.FlatAppearance.BorderSize = 0;
+            stopButton.Click += (s, e) =>
+            {
+                StopClicked = true;
+                stopButton.Enabled = false;
+                stopButton.Text = "STOPPING...";
+                stopButton.BackColor = Color.Gray;
+            };
+
+            // Position stop button at the bottom center
+            stopButton.Location = new Point((f.Width - stopButton.Width) / 2, f.Height - stopButton.Height - 15);
+
+            panel.Controls.Add(stopButton);
             panel.Controls.Add(percentLabel);
             panel.Controls.Add(titleLabel);
             f.Controls.Add(panel);
@@ -155,6 +181,12 @@ namespace GameStoreLibraryManager.Common
         public void Close()
         {
             shouldClose = true;
+        }
+
+        public void ShowStopButton(bool show)
+        {
+            if (form == null || form.IsDisposed) return;
+            try { form.BeginInvoke(new Action(() => { if (stopButton != null) stopButton.Visible = show; })); } catch { }
         }
     }
 }

--- a/GameStoreLibraryManager/src/Luna/LunaBrowserForm.resx
+++ b/GameStoreLibraryManager/src/Luna/LunaBrowserForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GameStoreLibraryManager/src/Menu/MenuForm.resx
+++ b/GameStoreLibraryManager/src/Menu/MenuForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GameStoreLibraryManager/src/Steam/SteamStoreData.cs
+++ b/GameStoreLibraryManager/src/Steam/SteamStoreData.cs
@@ -62,8 +62,29 @@ namespace GameStoreLibraryManager.Steam
         [JsonProperty("thumbnail")]
         public string Thumbnail { get; set; }
 
+        [JsonProperty("webm")]
+        public WebMFiles Webm { get; set; }
+
         [JsonProperty("mp4")]
         public Mp4Files Mp4 { get; set; }
+
+        [JsonProperty("dash_h264")]
+        public string DashH264 { get; set; }
+
+        [JsonProperty("dash_av1")]
+        public string DashAv1 { get; set; }
+
+        [JsonProperty("hls_h264")]
+        public string HlsH264 { get; set; }
+    }
+
+    public class WebMFiles
+    {
+        [JsonProperty("480")]
+        public string Low { get; set; }
+
+        [JsonProperty("max")]
+        public string High { get; set; }
     }
 
     public class Mp4Files
@@ -87,25 +108,21 @@ namespace GameStoreLibraryManager.Steam
         public string PathFull { get; set; }
     }
 
-    // For GetAppList endpoint
-    public class SteamApp
+    public class SteamSearchResult
     {
-        [JsonProperty("appid")]
-        public int AppId { get; set; }
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        [JsonProperty("items")]
+        public List<SteamSearchItem> Items { get; set; }
+    }
+
+    public class SteamSearchItem
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }
-    }
-
-    public class AppList
-    {
-        [JsonProperty("apps")]
-        public List<SteamApp> Apps { get; set; }
-    }
-
-    public class AppListResponse
-    {
-        [JsonProperty("applist")]
-        public AppList AppList { get; set; }
     }
 }

--- a/GameStoreLibraryManager/src/SteamGridDb/SteamGridDbScraper.cs
+++ b/GameStoreLibraryManager/src/SteamGridDb/SteamGridDbScraper.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using GameStoreLibraryManager.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GameStoreLibraryManager.SteamGridDb
+{
+    public class SteamGridDbScraper
+    {
+        private readonly HttpClient _httpClient;
+        private readonly Config _config;
+        private string _apiKey;
+        private const string BaseUrl = "https://www.steamgriddb.com/api/v2";
+
+        public SteamGridDbScraper(Config config)
+        {
+            _config = config;
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "GSLM/1.0");
+            LoadApiKey();
+        }
+
+        private void LoadApiKey()
+        {
+            _apiKey = _config.GetString("steamgriddb_api_key", "");
+            
+            // If empty in config, try reading from file (automated auth target)
+            if (string.IsNullOrEmpty(_apiKey))
+            {
+                string apiKeyPath = Path.Combine(PathManager.ApiKeyPath, "steamgriddb.apikey");
+                if (File.Exists(apiKeyPath))
+                {
+                    _apiKey = SecureStore.ReadString(apiKeyPath)?.Trim();
+                    
+                    // Migrate to protected if enabled
+                    bool protect = _config.GetBoolean("enable_dpapi_protection", false);
+                    if (protect && !SecureStore.IsProtectedFile(apiKeyPath) && !string.IsNullOrEmpty(_apiKey))
+                    {
+                        SecureStore.WriteString(apiKeyPath, _apiKey, true);
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_apiKey))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            }
+        }
+
+        public async Task<string> FindGameIdAsync(string gameName, string steamAppId, SimpleLogger logger)
+        {
+            if (string.IsNullOrEmpty(_apiKey)) 
+            {
+                LoadApiKey(); // Try reloading in case it was just generated
+                if (string.IsNullOrEmpty(_apiKey)) return null;
+            }
+
+            try
+            {
+                // Try Steam AppID first if available
+                if (!string.IsNullOrEmpty(steamAppId))
+                {
+                    logger.Log($"  [SGDB Scraper] Searching by Steam AppID: {steamAppId}");
+                    var response = await _httpClient.GetAsync($"{BaseUrl}/games/steam/{steamAppId}");
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var json = await response.Content.ReadAsStringAsync();
+                        var data = JObject.Parse(json);
+                        if (data["success"]?.Value<bool>() == true)
+                        {
+                            return data["data"]?["id"]?.ToString();
+                        }
+                    }
+                }
+
+                // Fallback to name search
+                logger.Log($"  [SGDB Scraper] Searching by name: {gameName}");
+                var searchResponse = await _httpClient.GetAsync($"{BaseUrl}/search/autocomplete/{Uri.EscapeDataString(gameName)}");
+                if (searchResponse.IsSuccessStatusCode)
+                {
+                    var json = await searchResponse.Content.ReadAsStringAsync();
+                    var data = JObject.Parse(json);
+                    if (data["success"]?.Value<bool>() == true)
+                    {
+                        var games = data["data"] as JArray;
+                        if (games != null && games.Count > 0)
+                        {
+                            // Best match logic (simple first result or improved matching)
+                            var bestMatch = games[0];
+                            logger.Log($"  [SGDB Scraper] Found match: {bestMatch["name"]} (ID: {bestMatch["id"]})");
+                            return bestMatch["id"]?.ToString();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Log($"  [SGDB Scraper] Error finding game: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        public async Task<GameDetails> GetGameDetailsAsync(string gameId, SimpleLogger logger)
+        {
+            if (string.IsNullOrEmpty(gameId) || string.IsNullOrEmpty(_apiKey)) return null;
+
+            var details = new GameDetails { MediaUrls = new Dictionary<string, string>() };
+
+            try
+            {
+                // Fetch Grids (Covers)
+                var grids = await FetchBestMedia(gameId, "grids", logger);
+                if (!string.IsNullOrEmpty(grids)) details.MediaUrls["image"] = grids;
+
+                // Fetch Heroes (Fanarts)
+                var heroes = await FetchBestMedia(gameId, "heroes", logger);
+                if (!string.IsNullOrEmpty(heroes)) details.MediaUrls["fanart"] = heroes;
+
+                // Fetch Logos (Marquees)
+                var logos = await FetchBestMedia(gameId, "logos", logger);
+                if (!string.IsNullOrEmpty(logos)) details.MediaUrls["marquee"] = logos;
+            }
+            catch (Exception ex)
+            {
+                logger.Log($"  [SGDB Scraper] Error fetching assets: {ex.Message}");
+            }
+
+            return details.MediaUrls.Any() ? details : null;
+        }
+
+        private async Task<string> FetchBestMedia(string gameId, string type, SimpleLogger logger)
+        {
+            // type can be "grids", "heroes", "logos", "icons"
+            var response = await _httpClient.GetAsync($"{BaseUrl}/{type}/game/{gameId}?nsfw=false&humor=false");
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadAsStringAsync();
+                var data = JObject.Parse(json);
+                if (data["success"]?.Value<bool>() == true)
+                {
+                    var items = data["data"] as JArray;
+                    if (items != null && items.Count > 0)
+                    {
+                        // Priority: preferred styles? Or just highest upvoted (usually first)
+                        // For logos, we might prefer "official" or "white"
+                        // For now, take the first one
+                        return items[0]["url"]?.ToString();
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Introduce SteamGridDB support and enhance media scraping/UX across the app.

- Add SteamGridDbScraper (new scraper file) and config options: steamgriddb_api_key, steamgriddb_scraper_media_types, and steamgriddb_enable_token_generation.
- Integrate SteamGridDB into MediaScraper: optional automated auth trigger, SGDB media priority, and include SGDB in the fallback order for metadata.
- Menu UI: add SteamGridDB API key input, Login button and View Profile link; securely persist API key (uses SecureStore/optional DPAPI protection).
- Program.cs: improve splash overlay messaging, pass progress ranges into ScrapeMediaForLibrary, and handle stop requests/status updates.
- SplashOverlay: add STOP button, StopClicked flag, ShowStopButton API and UI wiring to allow cancelling long-running scraping.